### PR TITLE
add bounds to openmaptiles.yaml

### DIFF
--- a/openmaptiles.yaml
+++ b/openmaptiles.yaml
@@ -22,6 +22,7 @@ tileset:
   description: "A tileset showcasing all layers in OpenMapTiles. https://openmaptiles.org"
   attribution: '<a href="https://www.openmaptiles.org/" target="_blank">&copy; OpenMapTiles</a> <a href="https://www.openstreetmap.org/copyright" target="_blank">&copy; OpenStreetMap contributors</a>'
   center: [-12.2168, 28.6135, 4]
+  bounds: [-180.0,-85.0511,180.0,95.0511]
   maxzoom: 14
   minzoom: 0
   pixel_scale: 256


### PR DESCRIPTION
This PR adds a `bounds` key and global bounding box value to `openmaptiles.yaml`, following the schema in https://github.com/openmaptiles/openmaptiles/blob/master/openmaptiles.yaml.

Without it, the `make` script throws an error "openmaptiles.yaml has invalid data."